### PR TITLE
add trim spaces from ModuleName/PackageName; closes #78

### DIFF
--- a/internal/attachments/templates/backend/chi/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/chi/handlers.go.gotmpl
@@ -6,8 +6,8 @@ import (
 	{{ if .Tools.IsUseTempl }}
 	"github.com/angelofallars/htmx-go"
 
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ else }}
 	"path/filepath"
 

--- a/internal/attachments/templates/backend/chi/server.go.gotmpl
+++ b/internal/attachments/templates/backend/chi/server.go.gotmpl
@@ -20,7 +20,7 @@ var static embed.FS
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/default/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/default/handlers.go.gotmpl
@@ -6,8 +6,8 @@ import (
 	{{ if .Tools.IsUseTempl }}
 	"github.com/angelofallars/htmx-go"
 
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ else }}
 	"path/filepath"
 

--- a/internal/attachments/templates/backend/default/server.go.gotmpl
+++ b/internal/attachments/templates/backend/default/server.go.gotmpl
@@ -17,7 +17,7 @@ var static embed.FS
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/echo/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/echo/handlers.go.gotmpl
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	{{ if .Tools.IsUseTempl }}
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ end }}
 	"github.com/angelofallars/htmx-go"
 	"github.com/labstack/echo/v4"

--- a/internal/attachments/templates/backend/echo/server.go.gotmpl
+++ b/internal/attachments/templates/backend/echo/server.go.gotmpl
@@ -38,7 +38,7 @@ func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Con
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/fiber/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/fiber/handlers.go.gotmpl
@@ -3,8 +3,8 @@ package main
 import (
 	{{ if .Tools.IsUseTempl }}
 	"github.com/a-h/templ"
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	{{ end }}
 	"github.com/gofiber/fiber/v2"

--- a/internal/attachments/templates/backend/fiber/server.go.gotmpl
+++ b/internal/attachments/templates/backend/fiber/server.go.gotmpl
@@ -16,7 +16,7 @@ import (
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/gin/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/gin/handlers.go.gotmpl
@@ -7,8 +7,8 @@ import (
 	{{ if .Tools.IsUseTempl }}
 	"github.com/angelofallars/htmx-go"
 
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ else }}
 	"path/filepath"
 

--- a/internal/attachments/templates/backend/gin/server.go.gotmpl
+++ b/internal/attachments/templates/backend/gin/server.go.gotmpl
@@ -54,7 +54,7 @@ func (t *TemplRender) Instance(name string, data interface{}) render.Render {
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/go.mod.gotmpl
+++ b/internal/attachments/templates/backend/go.mod.gotmpl
@@ -1,4 +1,4 @@
-module {{ .Backend.ModuleName }}
+module {{ trim .Backend.ModuleName }}
 
 go 1.22.0
 

--- a/internal/attachments/templates/backend/httprouter/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/httprouter/handlers.go.gotmpl
@@ -7,8 +7,8 @@ import (
 	{{ if .Tools.IsUseTempl }}
 	"github.com/angelofallars/htmx-go"
 
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ else }}
 	"path/filepath"
 

--- a/internal/attachments/templates/backend/httprouter/server.go.gotmpl
+++ b/internal/attachments/templates/backend/httprouter/server.go.gotmpl
@@ -19,7 +19,7 @@ var static embed.FS
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/backend/pocketbase/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/pocketbase/handlers.go.gotmpl
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	{{ if .Tools.IsUseTempl }}
-	"{{ .Backend.ModuleName }}/templates"
-	"{{ .Backend.ModuleName }}/templates/pages"
+	"{{ trim .Backend.ModuleName }}/templates"
+	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ end }}
 	"github.com/angelofallars/htmx-go"
 	"github.com/labstack/echo/v5"

--- a/internal/attachments/templates/backend/pocketbase/server.go.gotmpl
+++ b/internal/attachments/templates/backend/pocketbase/server.go.gotmpl
@@ -37,7 +37,7 @@ func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Con
 // runServer runs a new HTTP server with the loaded environment variables.
 func runServer() error {
 	// Validate environment variables.
-	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ .Backend.Port }}"))
+	port, err := strconv.Atoi(gowebly.Getenv("BACKEND_PORT", "{{ trim .Backend.Port }}"))
 	if err != nil {
 		return err
 	}

--- a/internal/attachments/templates/deploy/docker-compose.yml.gotmpl
+++ b/internal/attachments/templates/deploy/docker-compose.yml.gotmpl
@@ -14,12 +14,12 @@ services:
       dockerfile: Dockerfile
     # Set restart rules for the container.
     restart: unless-stopped
-    # Forward the exposed port {{ .Port }} on the container to port {{ .Port }} on the host machine.
+    # Forward the exposed port {{ trim .Port }} on the container to port {{ trim .Port }} on the host machine.
     ports:
-      - '{{ .Port }}:{{ .Port }}'
+      - '{{ trim .Port }}:{{ trim .Port }}'
     # Set needed environment variables for the Go backend.
     environment:
-      BACKEND_PORT: {{ .Port }} # same as the exposed container port
+      BACKEND_PORT: {{ trim .Port }} # same as the exposed container port
     # Networks to join.
     # Services on the same network can communicate with each other using their name.
     networks:

--- a/internal/attachments/templates/frontend/main.templ.gotmpl
+++ b/internal/attachments/templates/frontend/main.templ.gotmpl
@@ -1,6 +1,6 @@
 package templates
 
-import "{{ .Backend.ModuleName }}/templates/pages"
+import "{{ trim .Backend.ModuleName }}/templates/pages"
 
 templ Layout(title string, metaTags, bodyContent templ.Component) {
 	<!DOCTYPE html>

--- a/internal/attachments/templates/frontend/package.json.gotmpl
+++ b/internal/attachments/templates/frontend/package.json.gotmpl
@@ -1,5 +1,5 @@
 {
-  "name": "{{ .PackageName }}",
+  "name": "{{ trim .PackageName }}",
   "version": "0.0.0",
   "description": "Frontend part of the Gowebly project.",
   "license": "MIT",

--- a/internal/attachments/templates/misc/Makefile.gotmpl
+++ b/internal/attachments/templates/misc/Makefile.gotmpl
@@ -17,7 +17,7 @@ build: clean test
 	go build -o ${TEMP_DIR}/${BINARY_NAME} .
 
 run: build
-	@echo "\n> Running project on http://localhost:{{ .Backend.Port }}...\n"
+	@echo "\n> Running project on http://localhost:{{ trim .Backend.Port }}...\n"
 	${TEMP_DIR}/${BINARY_NAME}{{ if eq .Backend.GoFramework "pocketbase"}} --dir=pb_data serve{{end}}
 
 {{ if .Tools.IsUseGolangCILint }}

--- a/internal/helpers/embed_file_system.go
+++ b/internal/helpers/embed_file_system.go
@@ -6,6 +6,8 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/gowebly/gowebly/v2/internal/messages"
 )
@@ -63,7 +65,11 @@ func GenerateFilesByTemplateFromEmbedFS(efs embed.FS, templates []EmbedTemplate)
 		}
 
 		// Parse template from embed file system.
-		tmpl, err := template.ParseFS(efs, t.EmbedFile)
+		tmpl, err := template.New(filepath.Base(t.EmbedFile)).
+			Funcs(template.FuncMap{
+				"trim": strings.TrimSpace,
+			}).
+			ParseFS(efs, t.EmbedFile)
 		if err != nil {
 			return err
 		}

--- a/internal/variables/version.go
+++ b/internal/variables/version.go
@@ -1,4 +1,4 @@
 package variables
 
 // GoweblyVersion represents the current Gowebly CLI version.
-var GoweblyVersion string = "v2.5.1"
+var GoweblyVersion string = "v2.5.2"


### PR DESCRIPTION
**What this PR is changing or adding?**

<!-- Replace this paragraph with a description of what this PR is changing or adding, and why. -->

Trims spaces from ModuleName/PackageName in go templates.

This is less elegant because https://github.com/charmbracelet/bubbles/blob/v0.18.0/textinput/textinput.go does not support overriding default Sanitizer, that replaces newlines with spaces.

> This seems to occur only with Windows builds.

**Before/after or any other screenshots**

<!-- Consider including before/after screenshots. -->

**Which issues are fixed by this PR?**

<!-- List which issues are fixed by this PR. You must list at least one issue. -->

1. #78

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct][repo_coc_url].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.

<!-- Links -->

[repo_coc_url]: https://github.com/gowebly/.github/blob/main/CODE_OF_CONDUCT.md
