### PR TITLE
Fix bug in parsing of templates in echo

### DIFF
--- a/internal/attachments/templates/backend/echo/server.go.gotmpl
+++ b/internal/attachments/templates/backend/echo/server.go.gotmpl
@@ -26,7 +26,7 @@ type Template struct {
 
 // Render renders all templates, using gowebly helper.
 func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-	tmpl, err := gowebly.ParseTemplates(filepath.Join("templates", "pages", t.templates.Name()))
+	tmpl, err := gowebly.ParseTemplates(filepath.Join("templates", "pages", name))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR is changing or adding?**

Fixes a bug (typo?) that causes only one template to load regardless of the number of templates, in the previous version it'll only pick the first one that was registered.
