### PR TITLE
Fix Dockerfile template to copy over static files for Pocketbase as well

### DIFF
--- a/internal/attachments/templates/deploy/Dockerfile.gotmpl
+++ b/internal/attachments/templates/deploy/Dockerfile.gotmpl
@@ -21,7 +21,7 @@ FROM scratch
 
 # Copy project's binary and templates from /build to the scratch container.
 COPY --from=builder /build/gowebly_{{ .Backend.GoFramework }} /
-{{ if or (eq .Backend.GoFramework "echo") (eq .Backend.GoFramework "fiber") (eq .Backend.GoFramework "gin") }}COPY --from=builder /build/static /static{{ end }}
+{{ if or (eq .Backend.GoFramework "echo") (eq .Backend.GoFramework "fiber") (eq .Backend.GoFramework "gin") (eq .Backend.GoFramework "pocketbase") }}COPY --from=builder /build/static /static{{ end }}
 {{ if not .Tools.IsUseTempl }}COPY --from=builder /build/templates /templates{{ end }}
 
 # Set entry point.


### PR DESCRIPTION
**What this PR is changing or adding?**

This fixes the Dockerfile to copy needed static files when using Pocketbase as a backend

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct][repo_coc_url].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation and/or comments to the code.
- [ ] All existing and new tests are passing successfully.

<!-- Links -->

[repo_coc_url]: https://github.com/gowebly/.github/blob/main/CODE_OF_CONDUCT.md
