### PR TITLE
fix(pocketbase): update templates for PocketBase v0.23+ API

### DIFF
--- a/internal/actions/create_pocketbase_test.go
+++ b/internal/actions/create_pocketbase_test.go
@@ -1,0 +1,138 @@
+package actions
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gowebly/gowebly/v3/internal/attachments"
+	"github.com/gowebly/gowebly/v3/internal/config"
+	"github.com/gowebly/gowebly/v3/internal/helpers"
+	"github.com/gowebly/gowebly/v3/internal/injectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generatePocketsbaseBackend generates only the backend files for the PocketBase
+// framework into the given directory using the provided config.
+func generatePocketbaseBackend(t *testing.T, dir string, useTempl bool) {
+	t.Helper()
+
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	require.NoError(t, os.Chdir(dir))
+
+
+	cfg := config.New()
+	cfg.Backend.GoFramework = "pocketbase"
+	cfg.Backend.ModuleName = "github.com/test/mfp"
+	cfg.Backend.Port = "8080"
+	cfg.Tools.IsUseTempl = useTempl
+	att := attachments.New()
+	di := injectors.New(cfg, att)
+
+	require.NoError(t, createProjectFolders(di))
+	require.NoError(t, createBackendFiles(di))
+
+	if useTempl {
+		// Generate templ files from frontend templates.
+		templates := []helpers.EmbedTemplate{
+			{
+				EmbedFile:  "templates/frontend/main.templ.gotmpl",
+				OutputFile: "templates/main.templ",
+				Data:       cfg,
+			},
+			{
+				EmbedFile:  "templates/frontend/index.templ.gotmpl",
+				OutputFile: "templates/pages/index.templ",
+				Data:       cfg,
+			},
+		}
+		require.NoError(t, helpers.GenerateFilesByTemplateFromEmbedFS(att.Templates, templates))
+	} else {
+		// Generate html files from frontend templates.
+		templates := []helpers.EmbedTemplate{
+			{
+				EmbedFile:  "templates/frontend/main.html.gotmpl",
+				OutputFile: "templates/main.html",
+				Data:       cfg,
+			},
+			{
+				EmbedFile:  "templates/frontend/index.html.gotmpl",
+				OutputFile: "templates/pages/index.html",
+				Data:       cfg,
+			},
+		}
+		require.NoError(t, helpers.GenerateFilesByTemplateFromEmbedFS(att.Templates, templates))
+	}
+}
+
+// TestPocketbaseTemplatesGenerateAndCompile_Templ verifies that the generated
+// PocketBase backend code (templ variant) compiles successfully.
+func TestPocketbaseTemplatesGenerateAndCompile_Templ(t *testing.T) {
+	// integration test - requires templ CLI
+
+	dir := t.TempDir()
+	generatePocketbaseBackend(t, dir, true)
+
+	// Run templ generate.
+	if err := runCmd(dir, "templ", "generate"); err != nil {
+		t.Fatalf("templ generate failed: %v", err)
+	}
+
+	// Resolve go.mod dependencies and build.
+	if err := runCmd(dir, "go", "mod", "tidy"); err != nil {
+		t.Fatalf("go mod tidy failed: %v", err)
+	}
+	if err := runCmd(dir, "go", "build", "-o", os.DevNull, "."); err != nil {
+		t.Fatalf("go build failed: %v", err)
+	}
+}
+
+// TestPocketbaseTemplatesGenerateAndCompile_HTML verifies that the generated
+// PocketBase backend code (html/template variant) compiles successfully.
+func TestPocketbaseTemplatesGenerateAndCompile_HTML(t *testing.T) {
+	// integration test - requires network
+
+	dir := t.TempDir()
+	generatePocketbaseBackend(t, dir, false)
+
+	// Resolve go.mod dependencies and build.
+	if err := runCmd(dir, "go", "mod", "tidy"); err != nil {
+		t.Fatalf("go mod tidy failed: %v", err)
+	}
+	if err := runCmd(dir, "go", "build", "-o", os.DevNull, "."); err != nil {
+		t.Fatalf("go build failed: %v", err)
+	}
+}
+
+// TestPocketbaseTemplatesRender verifies that the gotmpl templates can be
+// rendered without errors for both the templ and html/template variants.
+func TestPocketbaseTemplatesRender(t *testing.T) {
+	for _, useTempl := range []bool{true, false} {
+		label := "html"
+		if useTempl {
+			label = "templ"
+		}
+		t.Run(label, func(t *testing.T) {
+			dir := t.TempDir()
+			generatePocketbaseBackend(t, dir, useTempl)
+
+			// Verify key files were generated.
+			assert.FileExists(t, filepath.Join(dir, "server.go"))
+			assert.FileExists(t, filepath.Join(dir, "handlers.go"))
+			assert.FileExists(t, filepath.Join(dir, "go.mod"))
+		})
+	}
+}
+
+// runCmd runs a command in the given directory.
+func runCmd(dir string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/attachments/templates/backend/pocketbase/handlers.go.gotmpl
+++ b/internal/attachments/templates/backend/pocketbase/handlers.go.gotmpl
@@ -9,14 +9,14 @@ import (
 	"{{ trim .Backend.ModuleName }}/templates/pages"
 	{{ end }}
 	"github.com/angelofallars/htmx-go"
-	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase/core"
 )
 
 // indexViewHandler handles a view for the index page.
-func indexViewHandler(c echo.Context) error {
+func indexViewHandler(e *core.RequestEvent) error {
 	{{ if .Tools.IsUseTempl }}
 	// Set the response content type to HTML.
-	c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextHTML)
+	e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	// Define template meta tags.
 	metaTags := pages.MetaTags(
@@ -37,25 +37,33 @@ func indexViewHandler(c echo.Context) error {
 		bodyContent,           // define body content
 	)
 
-	return htmx.NewResponse().RenderTempl(c.Request().Context(), c.Response().Writer, indexTemplate)
+	return htmx.NewResponse().RenderTempl(e.Request.Context(), e.Response, indexTemplate)
 	{{ else }}
-	return c.Render(http.StatusOK, "templates/pages/index.html", nil)
+	// Render the HTML template for the index page.
+	html, err := renderHTMLTemplate("index.html")
+	if err != nil {
+		return e.BadRequestError("failed to render template", err)
+	}
+
+	return e.HTML(http.StatusOK, html)
 	{{ end }}
 }
 
 // showContentAPIHandler handles an API endpoint to show content.
-func showContentAPIHandler(c echo.Context) error {
+func showContentAPIHandler(e *core.RequestEvent) error {
 	// Check, if the current request has a 'HX-Request' header.
 	// For more information, see https://htmx.org/docs/#request-headers
-	if !htmx.IsHTMX(c.Request()) {
+	if !htmx.IsHTMX(e.Request) {
 		// If not, return HTTP 400 error.
-		c.Response().WriteHeader(http.StatusBadRequest)
-		slog.Error("request API", "method", c.Request().Method, "status", http.StatusBadRequest, "path", c.Request().URL.Path)
-		return echo.NewHTTPError(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+		slog.Error("request API", "method", e.Request.Method, "status", http.StatusBadRequest, "path", e.Request.URL.Path)
+		return e.BadRequestError(http.StatusText(http.StatusBadRequest), nil)
 	}
 
 	// Write HTML content.
-	c.Response().Write([]byte("<p>🎉 Yes, <strong>htmx</strong> is ready to use! (<code>GET /api/hello-world</code>)</p>"))
+	_, err := e.Response.Write([]byte("<p>🎉 Yes, <strong>htmx</strong> is ready to use! (<code>GET /api/hello-world</code>)</p>"))
+	if err != nil {
+		return err
+	}
 
-	return htmx.NewResponse().Write(c.Response().Writer)
+	return htmx.NewResponse().Write(e.Response)
 }

--- a/internal/attachments/templates/backend/pocketbase/server.go.gotmpl
+++ b/internal/attachments/templates/backend/pocketbase/server.go.gotmpl
@@ -2,35 +2,38 @@ package main
 
 import (
 	{{ if not .Tools.IsUseTempl }}
-	"io"
+	"bytes"
 	"html/template"
 	"path/filepath"
 	{{ end }}
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 	"time"
 
-	"github.com/labstack/echo/v5/middleware"
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/hook"
 
 	gowebly "github.com/gowebly/helpers"
 )
 
 {{ if not .Tools.IsUseTempl }}
-// TemplateRegistry represents a custom 'html/template' renderer for Echo framework.
-type Template struct {
-	templates *template.Template
-}
-
-// Render renders all templates, using gowebly helper.
-func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
-	tmpl, err := gowebly.ParseTemplates(filepath.Join("templates", "pages", t.templates.Name()))
+// renderHTMLTemplate parses and executes the named template from the templates directory.
+func renderHTMLTemplate(name string) (string, error) {
+	tmpl, err := template.ParseFiles(filepath.Join("templates", "main.html"), filepath.Join("templates", "pages", name))
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return tmpl.Execute(w, nil)
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }
 {{ end }}
 
@@ -45,37 +48,42 @@ func runServer() error {
 	// Create a new PocketBase server.
 	app := pocketbase.New()
 
-	// Add PocketBase onBeforeServe middleware.
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		{{ if not .Tools.IsUseTempl }}
-		// Create a new Echo renderer for templates.
-		e.Router.Renderer = &Template{
-			templates: template.Must(template.ParseGlob("templates/**/*.html")),
-		}
-		{{ end }}
+	// Add PocketBase OnServe hook to register routes and middlewares.
+	//
+	// Since PocketBase v0.23, the old Echo-based router has been replaced
+	// with a thin wrapper around the standard net/http.ServeMux, and the
+	// OnBeforeServe hook was renamed to OnServe.
+	app.OnServe().Bind(&hook.Handler[*core.ServeEvent]{
+		Func: func(e *core.ServeEvent) error {
+			// Add a simple logger middleware.
+			e.Router.BindFunc(func(re *core.RequestEvent) error {
+				slog.Info("request", "method", re.Request.Method, "path", re.Request.URL.Path)
+				return re.Next()
+			})
 
-		// Add Echo middlewares.
-		e.Router.Use(middleware.Logger())
+			// Handle static files.
+			//
+			// Since PocketBase v0.23, Router.Static no longer exists.
+			// Use the apis.Static handler with a wildcard route parameter.
+			e.Router.GET("/static/{path...}", apis.Static(os.DirFS("./static"), false))
 
-		// Handle static files.
-		e.Router.Static("/static", "./static")
+			// Handle index page view.
+			e.Router.GET("/", indexViewHandler)
 
-		// Handle index page view.
-		e.Router.GET("/", indexViewHandler)
+			// Handle API endpoints.
+			e.Router.GET("/api/hello-world", showContentAPIHandler)
 
-		// Handle API endpoints.
-		e.Router.GET("/api/hello-world", showContentAPIHandler)
+			// Set server options from environment variables.
+			// For more information, see https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
+			// Note: The ReadTimeout and WriteTimeout settings may interfere with SSE (Server-Sent Event) or WS (WebSocket) connections.
+			// For SSE or WS, these timeouts can cause the connection to reset after 10 or 5 seconds due to the ReadTimeout and WriteTimeout settings.
+			// If you plan to use SSE or WS, consider commenting out or removing the ReadTimeout and WriteTimeout key-value pairs.
+			e.Server.Addr = fmt.Sprintf(":%d", port)
+			e.Server.ReadTimeout = 5 * time.Second
+			e.Server.WriteTimeout = 10 * time.Second
 
-		// Set server options from environment variables.
-		// For more information, see https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
-	    // Note: The ReadTimeout and WriteTimeout settings may interfere with SSE (Server-Sent Event) or WS (WebSocket) connections.
-        // For SSE or WS, these timeouts can cause the connection to reset after 10 or 5 seconds due to the ReadTimeout and WriteTimeout settings.
-        // If you plan to use SSE or WS, consider commenting out or removing the ReadTimeout and WriteTimeout key-value pairs.
-		e.Server.Addr = fmt.Sprintf(":%d", port)
-		e.Server.ReadTimeout = 5 * time.Second
-		e.Server.WriteTimeout = 10 * time.Second
-
-		return nil
+			return e.Next()
+		},
 	})
 
 	return app.Start()


### PR DESCRIPTION
## Problem

Projects generated with `gowebly create` using the PocketBase backend fail to compile. The generated code uses the old Echo v5-based router API that PocketBase removed in [v0.23.0](https://github.com/pocketbase/pocketbase/releases/tag/v0.23.0).

Since `go.mod.gotmpl` pins `github.com/pocketbase/pocketbase latest`, any new project pulls v0.23+ and gets 7 compile errors:

```
./handlers.go:39:76: c.Response().Writer undefined (type http.ResponseWriter has no field or method Writer)
./handlers.go:57:47: c.Response().Writer undefined (type http.ResponseWriter has no field or method Writer)
./server.go:27:6: app.OnBeforeServe undefined (type *pocketbase.PocketBase has no field or method OnBeforeServe)
./server.go:30:12: e.Router.Use undefined (type *router.Router[*core.RequestEvent] has no field or method Use)
./server.go:30:27: undefined: middleware.Logger
./server.go:33:12: e.Router.Static undefined (type *router.Router[*core.RequestEvent] has no field or method Static)
./server.go:36:21: cannot use indexViewHandler (value of type func(c echo.Context) error) as func(e *core.RequestEvent) error value in argument to e.Router.GET
```

PocketBase v0.23 was a [major refactor](https://deepwiki.com/pocketbase/site/6.4-version-upgrade-guide-(v0.23)) that dropped Echo entirely in favor of a custom `tools/router` package built on `net/http.ServeMux`. The `go.mod.gotmpl` also never added `github.com/labstack/echo/v5` as a dependency — it was only available transitively through old PocketBase, so the generated code was broken even before v0.23 if you ran `go mod tidy`.

## Changes

### `server.go.gotmpl`
| Old (Echo v5) | New (PocketBase v0.23+) |
|---|---|
| `app.OnBeforeServe().Add(func(e *core.ServeEvent) error {…})` | `app.OnServe().Bind(&hook.Handler[*core.ServeEvent]{Func: …})` |
| `e.Router.Use(middleware.Logger())` | `e.Router.BindFunc(func(re *core.RequestEvent) error { slog.Info(…); return re.Next() })` |
| `e.Router.Static("/static", "./static")` | `e.Router.GET("/static/{path...}", apis.Static(os.DirFS("./static"), false))` |
| `return nil` | `return e.Next()` (required for the serve chain to proceed) |
| Echo `Template` renderer with `c echo.Context` | `renderHTMLTemplate()` helper (html/template variant only) |

### `handlers.go.gotmpl`
| Old (Echo v5) | New (PocketBase v0.23+) |
|---|---|
| `func indexViewHandler(c echo.Context) error` | `func indexViewHandler(e *core.RequestEvent) error` |
| `c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextHTML)` | `e.Response.Header().Set("Content-Type", "text/html; charset=utf-8")` |
| `c.Request().Context()` / `c.Response().Writer` | `e.Request.Context()` / `e.Response` |
| `c.Render(http.StatusOK, "templates/pages/index.html", nil)` | `renderHTMLTemplate("index.html")` + `e.HTML(http.StatusOK, html)` |
| `c.Response().WriteHeader(http.StatusBadRequest)` + `echo.NewHTTPError(...)` | `e.BadRequestError(http.StatusText(...), nil)` |

### `create_pocketbase_test.go` (new)
Integration tests that:
1. Generate both templ and html/template variants from the gotmpl templates
2. Run `templ generate` (templ variant) and `go build` to verify the generated code compiles against the latest PocketBase
3. Verify template rendering succeeds for both variants

## Verification

All tests pass:

```
=== RUN   TestPocketbaseTemplatesGenerateAndCompile_Templ
--- PASS (1.70s)
=== RUN   TestPocketbaseTemplatesGenerateAndCompile_HTML
--- PASS (1.73s)
=== RUN   TestPocketbaseTemplatesRender
    --- PASS: templ
    --- PASS: html
--- PASS
```

Existing tests remain green:

```
=== RUN   TestCreateProjectFolders
--- PASS
=== RUN   TestCreateProjectFolders_AlreadyExists
--- PASS
=== RUN   TestCreateProjectAction_Success
--- PASS
=== RUN   TestCreateProjectAction_ContextCancellation
--- PASS
```

## Scope

Only the `pocketbase` backend templates are changed. The `echo` (v4) backend templates and all other backends are untouched.